### PR TITLE
Added GROMACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Current test plan:
   https://github.com/hpcg-benchmark/hpcg
 - HPL
   https://netlib.org/benchmark/hpl/ 
-
+- GROMACS
+  https://www.gromacs.org/ A free and open-source software suite for high-performance molecular dynamics and output analysis. 
 Please Submit a PR and append the software you want to run on our RISC-V clusters directly.
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Current test plan:
 - HPL
   https://netlib.org/benchmark/hpl/ 
 - GROMACS
-  https://www.gromacs.org/ A free and open-source software suite for high-performance molecular dynamics and output analysis. 
+  https://www.gromacs.org/ A free and open-source software suite for high-performance molecular dynamics and output analysis.
+ 
 Please Submit a PR and append the software you want to run on our RISC-V clusters directly.
 
 


### PR DESCRIPTION
如题， GROMACS 是分子动力学研究中较为重要的软件，被常用于生物医药领域的计算，支持 MPI 等特性。希望可以使用你们的节点尝试运行 GROMACS ，从而测试中大型 RISC-V 计算集群运行专用软件的性能。